### PR TITLE
chore: add GitVersion.yaml with conventional commit config

### DIFF
--- a/GitVersion.yaml
+++ b/GitVersion.yaml
@@ -1,0 +1,3 @@
+major-version-bump-message: '(breaking|major)'
+minor-version-bump-message: 'feat'
+patch-version-bump-message: '(fix|refactor)'


### PR DESCRIPTION
This is to prevent having to remember to put `+semver: minor` in commit messages and instead just rely on conventional commits for releases.