### PR TITLE
feat: make copy use other fields

### DIFF
--- a/cmd/copy.go
+++ b/cmd/copy.go
@@ -12,19 +12,24 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var Copy = &cobra.Command{
-	Short: "Copies the password of a reference to the clipboard.",
-	Long: `Copies the password of a reference to the clipboard.
+const DEFAULT_FIELD = "password"
 
-Reads a 'reference' from the database at 'file' and copies the password to the clipboard.
+var Copy = &cobra.Command{
+	Short: "Copies a field of a reference to the clipboard.",
+	Long: `Copies a field of a reference to the clipboard.
+
+Reads a 'reference' from the database at 'file' and copies the value of 'field' to the clipboard.
 
 The 'file' is the the path to the *.kdbx database. It can be passed either as an argument or via the ` + ENV_DATABASE + ` environment variable.
 The 'reference' can be passed either as the last argument, or can be read from stdin - to allow piping.
 Use the 'list' command to get a list of all the references in the database.
 
 See "Examples" for more details.`,
-	Example: `  # Copy the "github" entry in the "coding" group in the "test" database at test.kdbx
+	Example: `  # Copy the password of the "github" entry in the "coding" group in the "test" database at test.kdbx
   ` + info.NAME + ` copy test.kdbx /test/coding/github
+  
+  # Or copy the username instead
+  ` + info.NAME + ` copy -f username test.kdbx /test/coding/github
 
   # Or with stdin
   export ` + ENV_PASSPHRASE + `=${MY_SECRET_PHRASE}
@@ -35,29 +40,32 @@ See "Examples" for more details.`,
   export ` + ENV_DATABASE + `=test.kdbx
   echo "/test/coding/github" | ` + info.NAME + ` copy
 
-  # List entries, browse them with fzf and copy the result to the clipboard
+  # List entries, browse them with fzf and copy the username to the clipboard
   export ` + ENV_PASSPHRASE + `=${MY_SECRET_PHRASE}
   export ` + ENV_DATABASE + `=test.kdbx
 
-  ` + info.NAME + ` list | fzf | ` + info.NAME + ` copy`,
+  ` + info.NAME + ` list | fzf | ` + info.NAME + ` copy -f username`,
 	Use:     "copy [file] [reference]",
-	Aliases: []string{"cp", "password", "pwd", "copy-password"},
+  // Initially this command only copied passowrds, hence the aliases.
+  // Keeping them around for backwards compatibility.
+  Aliases: []string{"cp", "password", "pwd", "copy-password"},
 	Args: cobra.MatchAll(
 		cobra.MaximumNArgs(2),
 		DatabaseMustBeDefined(),
 	),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		database, reference, key := ReadDatabaseArguments(cmd, args)
+    field := cmd.Flag("field").Value.String()
 		log.Debugf("Using: database %s, reference %s, key %s", database, reference, key)
 
     passphrase := credentials.GetPassphrase(database, os.Getenv(ENV_PASSPHRASE))
 
-		return copy(database, key, passphrase, reference)
+		return copy(database, key, passphrase, reference, field)
 	},
 	DisableAutoGenTag: true,
 }
 
-func copy(databasePath, keyPath, passphrase, reference string) error {
+func copy(databasePath, keyPath, passphrase, reference, field string) error {
 	reference, err := ReadReferenceFromStdin(reference)
 	if err != nil {
 		return err
@@ -69,7 +77,19 @@ func copy(databasePath, keyPath, passphrase, reference string) error {
 	}
 
 	if entry := db.GetFirstEntryByPath(reference); entry != nil {
-		return clipboard.Write(entry.GetPassword())
+    var value string
+    
+    if field == DEFAULT_FIELD {
+      value = entry.GetPassword()
+    } else {
+      value = entry.GetContent(field)
+    }
+
+    if value == "" {
+      return errors.MakeError(`Missing field "`+field+`" in entry `+reference, "copy")
+    }
+
+    return clipboard.Write(value)
 	}
 
 	return errors.MakeError("Missing entry at "+reference, "copy")

--- a/cmd/copy.go
+++ b/cmd/copy.go
@@ -45,20 +45,20 @@ See "Examples" for more details.`,
   export ` + ENV_DATABASE + `=test.kdbx
 
   ` + info.NAME + ` list | fzf | ` + info.NAME + ` copy -f username`,
-	Use:     "copy [file] [reference]",
-  // Initially this command only copied passowrds, hence the aliases.
-  // Keeping them around for backwards compatibility.
-  Aliases: []string{"cp", "password", "pwd", "copy-password"},
+	Use: "copy [file] [reference]",
+	// Initially this command only copied passowrds, hence the aliases.
+	// Keeping them around for backwards compatibility.
+	Aliases: []string{"cp", "password", "pwd", "copy-password"},
 	Args: cobra.MatchAll(
 		cobra.MaximumNArgs(2),
 		DatabaseMustBeDefined(),
 	),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		database, reference, key := ReadDatabaseArguments(cmd, args)
-    field := cmd.Flag("field").Value.String()
+		field := cmd.Flag("field").Value.String()
 		log.Debugf("Using: database %s, reference %s, key %s", database, reference, key)
 
-    passphrase := credentials.GetPassphrase(database, os.Getenv(ENV_PASSPHRASE))
+		passphrase := credentials.GetPassphrase(database, os.Getenv(ENV_PASSPHRASE))
 
 		return copy(database, key, passphrase, reference, field)
 	},
@@ -77,19 +77,19 @@ func copy(databasePath, keyPath, passphrase, reference, field string) error {
 	}
 
 	if entry := db.GetFirstEntryByPath(reference); entry != nil {
-    var value string
-    
-    if field == DEFAULT_FIELD {
-      value = entry.GetPassword()
-    } else {
-      value = entry.GetContent(field)
-    }
+		var value string
 
-    if value == "" {
-      return errors.MakeError(`Missing field "`+field+`" in entry `+reference, "copy")
-    }
+		if field == DEFAULT_FIELD {
+			value = entry.GetPassword()
+		} else {
+			value = entry.GetContent(field)
+		}
 
-    return clipboard.Write(value)
+		if value == "" {
+			return errors.MakeError(`Missing field "`+field+`" in entry `+reference, "copy")
+		}
+
+		return clipboard.Write(value)
 	}
 
 	return errors.MakeError("Missing entry at "+reference, "copy")

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -13,7 +13,7 @@ var Root = &cobra.Command{
 ` + info.NAME + ` can read the following environment variables:
 
   - ` + ENV_PASSPHRASE + ` 
-    When this variable is set, keydex will skip the password prompt. It can be replaced by utils such as 'autoexpect'.
+    When this variable is set, ` + info.NAME + ` will skip the password prompt. It can be replaced by utils such as 'autoexpect'.
 
   - ` + ENV_DATABASE + `
     Is the path to the *.kbdx database to unlock. Providing 'file' inline overrides this value.

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -21,7 +21,7 @@ var Root = &cobra.Command{
   - ` + ENV_KEY + `
     Is the path to the optional *.key file used to unlock the database. Providing the '--key' flag inline overrides this value.
 
-All the entries are referenced with a path-like reference string shaped like /database/group1/../groupN/entry where 'database' is the database name, 'groupX' is the group name, and 'entry' is the entry title. 
+All the entries are referenced with a path-like reference string shaped like /database/group1/../groupN/entry where 'database' is the database name, 'groupN' is the group name, and 'entry' is the entry title. 
 
 Internally all the entries are referenced by a UUID, however ` + info.NAME + ` will read the first occurrence of a reference in cases of conflicts. Writes are always done via UUID and they are threfore conflict-safe.
     
@@ -39,4 +39,5 @@ func init() {
 	Root.AddCommand(Open)
 
 	Root.PersistentFlags().StringP("key", "k", "", "path to the key file to unlock the database")
+  Copy.Flags().StringP("field", "f", DEFAULT_FIELD, "field whose value will be copied")
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -39,5 +39,5 @@ func init() {
 	Root.AddCommand(Open)
 
 	Root.PersistentFlags().StringP("key", "k", "", "path to the key file to unlock the database")
-  Copy.Flags().StringP("field", "f", DEFAULT_FIELD, "field whose value will be copied")
+	Copy.Flags().StringP("field", "f", DEFAULT_FIELD, "field whose value will be copied")
 }


### PR DESCRIPTION
This change will allow `copy` to copy the value of other fields, instead of password only.

This closes #14  