### PR TITLE
feat: introduce read-only mode

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -40,4 +40,5 @@ func init() {
 
 	Root.PersistentFlags().StringP("key", "k", "", "path to the key file to unlock the database")
 	Copy.Flags().StringP("field", "f", DEFAULT_FIELD, "field whose value will be copied")
+	Open.Flags().Bool("read-only", false, "open "+info.NAME+" in read-only mode")
 }

--- a/docs/keydex_open.md
+++ b/docs/keydex_open.md
@@ -42,7 +42,8 @@ keydex open [file] [reference] [flags]
 ### Options
 
 ```
-  -h, --help   help for open
+  -h, --help        help for open
+      --read-only   open keydex in read-only mode
 ```
 
 ### Options inherited from parent commands

--- a/tui/app.go
+++ b/tui/app.go
@@ -74,6 +74,7 @@ type State struct {
 	Database          *kdbx.Database
 	Reference         string
 	HasUnsavedChanges bool
+	IsReadOnly        bool
 }
 
 func Run(state State) error {

--- a/tui/components/field/field.go
+++ b/tui/components/field/field.go
@@ -18,6 +18,7 @@ type FieldOptions struct {
 	Label        string
 	InitialValue string
 	InputType    InputType
+	Disabled     bool
 }
 
 func (f *Field) HasFocus() bool {
@@ -61,7 +62,7 @@ func NewField(options *FieldOptions) *Field {
 	field := &Field{}
 	field.SetOrientation(views.Horizontal)
 
-	opts := &InputOptions{InitialValue: options.InitialValue, Type: options.InputType}
+	opts := &InputOptions{InitialValue: options.InitialValue, Type: options.InputType, Disabled: options.Disabled}
 	input := NewInput(opts)
 	input.SetContent(options.InitialValue)
 	input.SetInputType(options.InputType)

--- a/tui/components/field/field.go
+++ b/tui/components/field/field.go
@@ -45,6 +45,10 @@ func (f *Field) OnKeyPress(cb func(ev *tcell.EventKey) bool) func() {
 	return f.input.OnKeyPress(cb)
 }
 
+func (f* Field) OnChange(cb func(ev tcell.Event) bool) func() {
+	return f.input.OnChange(cb)
+}
+
 func (f *Field) GetContent() string {
 	return f.input.GetContent()
 }

--- a/tui/components/field/input.go
+++ b/tui/components/field/input.go
@@ -25,6 +25,7 @@ type Input struct {
 type InputOptions struct {
 	InitialValue string
 	Type         InputType
+	Disabled     bool
 }
 
 type InputType int
@@ -65,8 +66,10 @@ type inputModel struct {
 	y int
 	// Style. See tcell.Style for details
 	style tcell.Style
-	// Returns true if the field is focused
+	// True if the field is focused
 	hasFocus bool
+	// True if the field is disables
+	disabled bool
 	// Whether the field is a password field or a regular one
 	inputType InputType
 
@@ -245,6 +248,14 @@ func (i *Input) HandleEvent(ev tcell.Event) bool {
 				return true
 			}
 			return false
+		}
+
+		// Prevent all input-changing actions when the field is disabled
+		if i.model.disabled {
+			return true
+		}
+
+		switch ev.Key() {
 		case tcell.KeyEnter:
 			return i.handleCellsUpdate(
 				ev,
@@ -384,6 +395,7 @@ func NewInput(options *InputOptions) *Input {
 	i := &Input{}
 	i.Init()
 	i.model.inputType = options.Type
+	i.model.disabled = options.Disabled
 	return i
 }
 

--- a/tui/components/field/input_test.go
+++ b/tui/components/field/input_test.go
@@ -310,6 +310,7 @@ func TestInput_HandleEvent(t *testing.T) {
 		name        string
 		content     string
 		hasFocus    bool
+		disabled    bool
 		x, y        int
 		event       tcell.Event
 		wantHandled bool
@@ -532,11 +533,63 @@ func TestInput_HandleEvent(t *testing.T) {
 			wantY:       1,
 			wantCells:   [][]rune{{'a', 'b', 'c'}, {'d'}},
 		},
+		{
+			name:        "disabled input (rune)",
+			content:     "abc",
+			hasFocus:    true,
+			disabled:    true,
+			x:           1,
+			y:           0,
+			event:       tcell.NewEventKey(tcell.KeyRune, 'd', 0),
+			wantHandled: true,
+			wantX:       1,
+			wantY:       0,
+			wantCells:   [][]rune{{'a', 'b', 'c'}},
+		},
+		{
+			name:        "disabled input (delete)",
+			content:     "abc",
+			hasFocus:    true,
+			disabled:    true,
+			x:           1,
+			y:           0,
+			event:       tcell.NewEventKey(tcell.KeyDelete, 0, 0),
+			wantHandled: true,
+			wantX:       1,
+			wantY:       0,
+			wantCells:   [][]rune{{'a', 'b', 'c'}},
+		},
+		{
+			name:        "disabled input (enter)",
+			content:     "abc",
+			hasFocus:    true,
+			disabled:    true,
+			x:           3,
+			y:           0,
+			event:       tcell.NewEventKey(tcell.KeyEnter, 0, 0),
+			wantHandled: true,
+			wantX:       3,
+			wantY:       0,
+			wantCells:   [][]rune{{'a', 'b', 'c'}},
+		},
+		{
+			name:        "disabled input (backspace)",
+			content:     "abc",
+			hasFocus:    true,
+			disabled:    true,
+			x:           1,
+			y:           0,
+			event:       tcell.NewEventKey(tcell.KeyBackspace, 0, 0),
+			wantHandled: true,
+			wantX:       1,
+			wantY:       0,
+			wantCells:   [][]rune{{'a', 'b', 'c'}},
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			i := NewInput(&InputOptions{})
+			i := NewInput(&InputOptions{Disabled: tt.disabled})
 			i.SetFocus(tt.hasFocus)
 			i.SetContent(tt.content)
 			i.SetCursor(tt.x, tt.y)

--- a/tui/open.go
+++ b/tui/open.go
@@ -136,9 +136,12 @@ func (view *HomeView) newEntryField(label, initialValue string, isProtected bool
 		return true
 	})
 
-	f.OnKeyPress(func(ev *tcell.EventKey) bool {
+	f.OnChange(func(ev tcell.Event) bool {
 		App.State.HasUnsavedChanges = true
+		return false
+	})
 
+	f.OnKeyPress(func(ev *tcell.EventKey) bool {
 		if ev.Name() == "Ctrl+C" {
 			clipboard.Write(string(f.GetContent()))
 			App.Notify(fmt.Sprintf("Copied \"%s\" to the clipboard.", label))


### PR DESCRIPTION
This change introduces the read-only mode for keydex. Users can decide to launch keydex in read-only mode by means of a CLI flag: --read-only.

This change entails, more specifically the following parts:
* allowing to disable fields
* which in turn means disabling inputs
* drilling the read-only/disabled property down where needed

## TODO
- [x] Fix the "Are you sure" message when you are closing after taking action. Not related to this change, but this change made it more noticeable.

Closes #21 