### PR TITLE
feat: `diff` to compare archives

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,4 +15,4 @@ jobs:
       - run: make test
       - run: make docs
       - name: Verify no stale documentation
-        run: git diff --exit-code -- . ':(exclude)**/*.md'
+        run: git diff --exit-code

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -90,6 +90,15 @@ interactive input).
 </details>
 
 <details>
+<summary>Diff</summary>
+
+**Compare two archives with interactive prompts**
+1. `keydex diff old.kdbx new.kdbx` (no env vars set)
+   - **Expected:** prompted for passphrase A, then passphrase B; diff output printed to stdout
+
+</details>
+
+<details>
 <summary>Smoke tests</summary>
 
 Quick walkthrough of the most important flows to sanity-check a

--- a/cmd/diff.go
+++ b/cmd/diff.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 
 	"github.com/shikaan/keydex/pkg/credentials"
+	"github.com/shikaan/keydex/pkg/errors"
 	"github.com/shikaan/keydex/pkg/info"
 	"github.com/shikaan/keydex/pkg/kdbx"
 	"github.com/shikaan/keydex/pkg/log"
@@ -39,6 +40,15 @@ Passphrases can be provided via environment variables to avoid interactive promp
 
 		log.Infof("Using: file-a: %s, key-a: %s, file-b: %s, key-b: %s",
 			fileA, orDefault(keyA), fileB, orDefault(keyB))
+
+		for _, f := range []string{fileA, fileB} {
+			if _, err := os.Stat(f); err != nil {
+				if pathErr, ok := err.(*os.PathError); ok {
+					return errors.MakeError("Cannot open "+f+": "+pathErr.Err.Error(), "diff")
+				}
+				return errors.MakeError("Cannot open "+f+": "+err.Error(), "diff")
+			}
+		}
 
 		passphraseA := credentials.GetPassphrase(fileA, os.Getenv(ENV_PASSPHRASE_A))
 		passphraseB := credentials.GetPassphrase(fileB, os.Getenv(ENV_PASSPHRASE_B))

--- a/cmd/diff.go
+++ b/cmd/diff.go
@@ -59,8 +59,17 @@ func diff(fileA, fileB, keyA, keyB, passphraseA, passphraseB string) error {
 		return err
 	}
 
+	statA, err := os.Stat(fileA)
+	if err != nil {
+		return err
+	}
+	statB, err := os.Stat(fileB)
+	if err != nil {
+		return err
+	}
+
 	diffs := kdbx.DiffDatabases(dbA, dbB)
-	fmt.Print(kdbx.FormatDiff(filepath.Base(fileA), filepath.Base(fileB), diffs))
+	fmt.Print(kdbx.FormatDiff(filepath.Base(fileA), filepath.Base(fileB), statA.ModTime(), statB.ModTime(), diffs))
 
 	return nil
 }

--- a/cmd/diff.go
+++ b/cmd/diff.go
@@ -1,0 +1,65 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/shikaan/keydex/pkg/credentials"
+	"github.com/shikaan/keydex/pkg/info"
+	"github.com/shikaan/keydex/pkg/kdbx"
+	"github.com/shikaan/keydex/pkg/log"
+	"github.com/spf13/cobra"
+)
+
+var Diff = &cobra.Command{
+	Short: "Compares two KeePass archives",
+	Long: `Compares two KeePass archives and outputs which entries were added, removed,
+or modified. Output follows the unified diff format so it can be piped into other tools.
+
+The 'file-a' and 'file-b' arguments are paths to the *.kdbx archives to compare.
+Passphrases can be provided via environment variables to avoid interactive prompts.`,
+	Use: "diff [file-a] [file-b]",
+	Args: cobra.ExactArgs(2),
+	Example: `  # Compare two archives
+  ` + info.NAME + ` diff old.kdbx new.kdbx
+
+  # Or with environment variables
+  export ` + ENV_PASSPHRASE_A + `=${PASSPHRASE_A}
+  export ` + ENV_PASSPHRASE_B + `=${PASSPHRASE_B}
+  ` + info.NAME + ` diff old.kdbx new.kdbx
+
+  # With key files
+  ` + info.NAME + ` diff --key-a old.key --key-b new.key old.kdbx new.kdbx`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		fileA, fileB := args[0], args[1]
+
+		keyA, _ := cmd.Flags().GetString("key-a")
+		keyB, _ := cmd.Flags().GetString("key-b")
+
+		log.Infof("Using: file-a: %s, key-a: %s, file-b: %s, key-b: %s",
+			fileA, orDefault(keyA), fileB, orDefault(keyB))
+
+		passphraseA := credentials.GetPassphrase(fileA, os.Getenv(ENV_PASSPHRASE_A))
+		passphraseB := credentials.GetPassphrase(fileB, os.Getenv(ENV_PASSPHRASE_B))
+
+		return diff(fileA, fileB, keyA, keyB, passphraseA, passphraseB)
+	},
+	DisableAutoGenTag: true,
+}
+
+func diff(fileA, fileB, keyA, keyB, passphraseA, passphraseB string) error {
+	dbA, err := kdbx.OpenFromPath(fileA, passphraseA, keyA)
+	if err != nil {
+		return err
+	}
+
+	dbB, err := kdbx.OpenFromPath(fileB, passphraseB, keyB)
+	if err != nil {
+		return err
+	}
+
+	diffs := kdbx.DiffDatabases(dbA, dbB)
+	fmt.Print(kdbx.FormatDiff(fileA, fileB, diffs))
+
+	return nil
+}

--- a/cmd/diff.go
+++ b/cmd/diff.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"fmt"
 	"os"
+	"path/filepath"
 
 	"github.com/shikaan/keydex/pkg/credentials"
 	"github.com/shikaan/keydex/pkg/info"
@@ -59,7 +60,7 @@ func diff(fileA, fileB, keyA, keyB, passphraseA, passphraseB string) error {
 	}
 
 	diffs := kdbx.DiffDatabases(dbA, dbB)
-	fmt.Print(kdbx.FormatDiff(fileA, fileB, diffs))
+	fmt.Print(kdbx.FormatDiff(filepath.Base(fileA), filepath.Base(fileB), diffs))
 
 	return nil
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -46,6 +46,7 @@ func init() {
 	Root.AddCommand(List)
 	Root.AddCommand(Open)
 	Root.AddCommand(Create)
+	Root.AddCommand(Diff)
 
 	Copy.PersistentFlags().StringP("key", "k", "", "path to the key file to unlock the database")
 	List.PersistentFlags().StringP("key", "k", "", "path to the key file to unlock the database")
@@ -53,4 +54,7 @@ func init() {
 
 	Copy.Flags().StringP("field", "f", DEFAULT_FIELD, "field whose value will be copied")
 	Open.Flags().Bool("read-only", false, "open "+info.NAME+" in read-only mode")
+
+	Diff.Flags().String("key-a", "", "path to the key file for the first archive")
+	Diff.Flags().String("key-b", "", "path to the key file for the second archive")
 }

--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -11,6 +11,8 @@ import (
 
 const ENV_DATABASE = "KEYDEX_DATABASE"
 const ENV_PASSPHRASE = "KEYDEX_PASSPHRASE"
+const ENV_PASSPHRASE_A = "KEYDEX_PASSPHRASE_A"
+const ENV_PASSPHRASE_B = "KEYDEX_PASSPHRASE_B"
 const ENV_KEY = "KEYDEX_KEY"
 
 // If zero value reference is passed, reads from stdin to get the value

--- a/docs/keydex.md
+++ b/docs/keydex.md
@@ -45,6 +45,7 @@ keydex [flags]
 
 * [keydex copy](keydex_copy.md)	 - Copies a field of a reference to the clipboard.
 * [keydex create](keydex_create.md)	 - Create an empty KeePass archive.
+* [keydex diff](keydex_diff.md)	 - Compares two KeePass archives
 * [keydex list](keydex_list.md)	 - Lists all the entries in the database
 * [keydex open](keydex_open.md)	 - Open the entry editor for a reference.
 

--- a/docs/keydex_diff.md
+++ b/docs/keydex_diff.md
@@ -1,0 +1,43 @@
+## keydex diff
+
+Compares two KeePass archives
+
+### Synopsis
+
+Compares two KeePass archives and outputs which entries were added, removed,
+or modified. Output follows the unified diff format so it can be piped into other tools.
+
+The 'file-a' and 'file-b' arguments are paths to the *.kdbx archives to compare.
+Passphrases can be provided via environment variables to avoid interactive prompts.
+
+```
+keydex diff [file-a] [file-b] [flags]
+```
+
+### Examples
+
+```
+  # Compare two archives
+  keydex diff old.kdbx new.kdbx
+
+  # Or with environment variables
+  export KEYDEX_PASSPHRASE_A=${PASSPHRASE_A}
+  export KEYDEX_PASSPHRASE_B=${PASSPHRASE_B}
+  keydex diff old.kdbx new.kdbx
+
+  # With key files
+  keydex diff --key-a old.key --key-b new.key old.kdbx new.kdbx
+```
+
+### Options
+
+```
+  -h, --help           help for diff
+      --key-a string   path to the key file for the first archive
+      --key-b string   path to the key file for the second archive
+```
+
+### SEE ALSO
+
+* [keydex](keydex.md)	 - Manage KeePass databases from your terminal.
+

--- a/pkg/cli/cli.go
+++ b/pkg/cli/cli.go
@@ -12,7 +12,7 @@ import (
 
 var ReadSecret = func(prompt string) string {
 	result := ""
-	fmt.Print(prompt)
+	fmt.Fprint(os.Stderr, prompt)
 
 	for {
 		pw, err := term.ReadPassword(int(syscall.Stdin))
@@ -25,7 +25,7 @@ var ReadSecret = func(prompt string) string {
 		}
 	}
 
-	fmt.Println("")
+	fmt.Fprintln(os.Stderr, "")
 	return result
 }
 

--- a/pkg/cli/cli_test.go
+++ b/pkg/cli/cli_test.go
@@ -3,8 +3,38 @@ package cli
 import (
 	"io"
 	"os"
+	"strings"
 	"testing"
 )
+
+func TestReadSecret_promptGoesToStderr(t *testing.T) {
+	rErr, wErr, _ := os.Pipe()
+	oldStderr := os.Stderr
+	os.Stderr = wErr
+	defer func() { os.Stderr = oldStderr }()
+
+	rOut, wOut, _ := os.Pipe()
+	oldStdout := os.Stdout
+	os.Stdout = wOut
+	defer func() { os.Stdout = oldStdout }()
+
+	ReadSecret("secret-prompt: ")
+
+	wErr.Close()
+	wOut.Close()
+
+	stderrContent, _ := io.ReadAll(rErr)
+	stdoutContent, _ := io.ReadAll(rOut)
+	rErr.Close()
+	rOut.Close()
+
+	if !strings.Contains(string(stderrContent), "secret-prompt: ") {
+		t.Errorf("expected prompt on stderr, got stderr=%q stdout=%q", stderrContent, stdoutContent)
+	}
+	if strings.Contains(string(stdoutContent), "secret-prompt: ") {
+		t.Errorf("expected prompt NOT on stdout, got %q", stdoutContent)
+	}
+}
 
 func TestConfirm(t *testing.T) {
 	tests := []struct {

--- a/pkg/kdbx/diff.go
+++ b/pkg/kdbx/diff.go
@@ -1,0 +1,97 @@
+package kdbx
+
+import (
+	"slices"
+	"strings"
+	"time"
+)
+
+type ChangeStatus int
+
+const (
+	Unchanged ChangeStatus = iota
+	Added
+	Removed
+	Modified
+)
+
+type EntryDiff struct {
+	UUID   UUID
+	Path   EntityPath
+	Status ChangeStatus
+}
+
+type entryRecord struct {
+	path EntityPath
+	time time.Time
+}
+
+func DiffDatabases(a, b *Database) []EntryDiff {
+	aMap := makeRecordMap(a)
+	bMap := makeRecordMap(b)
+
+	seen := map[UUID]struct{}{}
+	for uuid := range aMap {
+		seen[uuid] = struct{}{}
+	}
+	for uuid := range bMap {
+		seen[uuid] = struct{}{}
+	}
+
+	result := []EntryDiff{}
+	for uuid := range seen {
+		aRec, inA := aMap[uuid]
+		bRec, inB := bMap[uuid]
+
+		var status ChangeStatus
+		var path EntityPath
+		switch {
+		case inA && !inB:
+			status = Removed
+			path = aRec.path
+		case !inA && inB:
+			status = Added
+			path = bRec.path
+		case aRec.time.Equal(bRec.time):
+			status = Unchanged
+			path = bRec.path
+		default:
+			status = Modified
+			path = bRec.path
+		}
+		result = append(result, EntryDiff{UUID: uuid, Path: path, Status: status})
+	}
+
+	slices.SortFunc(result, func(a, b EntryDiff) int {
+		return strings.Compare(a.Path, b.Path)
+	})
+
+	return result
+}
+
+func makeRecordMap(db *Database) map[UUID]entryRecord {
+	result := map[UUID]entryRecord{}
+	for _, g := range db.Content.Root.Groups {
+		collectRecords(g, PATH_SEPARATOR, result)
+	}
+	return result
+}
+
+func collectRecords(g Group, prefix string, out map[UUID]entryRecord) {
+	groupPrefix := makeGroupPrefix(prefix, g)
+
+	for _, sub := range g.Groups {
+		collectRecords(sub, groupPrefix, out)
+	}
+
+	for _, entry := range g.Entries {
+		var t time.Time
+		if entry.Times.LastModificationTime != nil {
+			t = entry.Times.LastModificationTime.Time
+		}
+		out[entry.UUID] = entryRecord{
+			path: makeEntryPath(groupPrefix, entry),
+			time: t,
+		}
+	}
+}

--- a/pkg/kdbx/diff.go
+++ b/pkg/kdbx/diff.go
@@ -78,7 +78,7 @@ func makeRecordMap(db *Database) map[UUID]entryRecord {
 }
 
 func collectRecords(g Group, prefix string, out map[UUID]entryRecord) {
-	groupPrefix := makeGroupPrefix(prefix, g)
+	groupPrefix := formatGroupPrefix(prefix, g)
 
 	for _, sub := range g.Groups {
 		collectRecords(sub, groupPrefix, out)
@@ -90,7 +90,7 @@ func collectRecords(g Group, prefix string, out map[UUID]entryRecord) {
 			t = entry.Times.LastModificationTime.Time
 		}
 		out[entry.UUID] = entryRecord{
-			path: makeEntryPath(groupPrefix, entry),
+			path: formatEntryPath(groupPrefix, entry),
 			time: t,
 		}
 	}

--- a/pkg/kdbx/diff.go
+++ b/pkg/kdbx/diff.go
@@ -62,8 +62,16 @@ func DiffDatabases(a, b *Database) []EntryDiff {
 		result = append(result, EntryDiff{UUID: uuid, Path: path, Status: status})
 	}
 
-	slices.SortFunc(result, func(a, b EntryDiff) int {
-		return strings.Compare(a.Path, b.Path)
+	slices.SortStableFunc(result, func(a, b EntryDiff) int {
+		if c := strings.Compare(a.Path, b.Path); c != 0 {
+			return c
+		}
+		for i := range a.UUID {
+			if d := int(a.UUID[i]) - int(b.UUID[i]); d != 0 {
+				return d
+			}
+		}
+		return 0
 	})
 
 	return result

--- a/pkg/kdbx/diff_test.go
+++ b/pkg/kdbx/diff_test.go
@@ -1,0 +1,139 @@
+package kdbx
+
+import (
+	"testing"
+	"time"
+
+	"github.com/tobischo/gokeepasslib/v3/wrappers"
+)
+
+func makeEntryAt(title string, t time.Time) Entry {
+	entry := makeEntry(title)
+	tw := wrappers.TimeWrapper{Time: t}
+	entry.Times.LastModificationTime = &tw
+	return entry
+}
+
+// atTime returns a copy of e with a different timestamp but the same UUID.
+func atTime(e Entry, t time.Time) Entry {
+	inner := *e.Entry
+	tw := wrappers.TimeWrapper{Time: t}
+	inner.Times.LastModificationTime = &tw
+	return Entry{&inner}
+}
+
+func TestDiffDatabases(t *testing.T) {
+	t0 := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+	t1 := time.Date(2024, 1, 2, 0, 0, 0, 0, time.UTC)
+
+	t.Run("empty databases", func(t *testing.T) {
+		a := makeDatabase("a.kdbx")
+		b := makeDatabase("b.kdbx")
+
+		got := DiffDatabases(a, b)
+
+		if len(got) != 0 {
+			t.Errorf("expected empty result, got %v", got)
+		}
+	})
+
+	t.Run("identical databases", func(t *testing.T) {
+		entry := makeEntryAt("GitHub", t0)
+		a := makeDatabase("a.kdbx", makeGroup("Passwords", entry))
+		b := makeDatabase("b.kdbx", makeGroup("Passwords", entry))
+
+		got := DiffDatabases(a, b)
+
+		if len(got) != 1 {
+			t.Fatalf("expected 1 diff, got %d", len(got))
+		}
+		if got[0].Status != Unchanged {
+			t.Errorf("expected Unchanged, got %v", got[0].Status)
+		}
+	})
+
+	t.Run("entry only in a", func(t *testing.T) {
+		entry := makeEntryAt("GitHub", t0)
+		a := makeDatabase("a.kdbx", makeGroup("Passwords", entry))
+		b := makeDatabase("b.kdbx", makeGroup("Passwords"))
+
+		got := DiffDatabases(a, b)
+
+		if len(got) != 1 {
+			t.Fatalf("expected 1 diff, got %d", len(got))
+		}
+		if got[0].Status != Removed {
+			t.Errorf("expected Removed, got %v", got[0].Status)
+		}
+	})
+
+	t.Run("entry only in b", func(t *testing.T) {
+		entry := makeEntryAt("GitHub", t0)
+		a := makeDatabase("a.kdbx", makeGroup("Passwords"))
+		b := makeDatabase("b.kdbx", makeGroup("Passwords", entry))
+
+		got := DiffDatabases(a, b)
+
+		if len(got) != 1 {
+			t.Fatalf("expected 1 diff, got %d", len(got))
+		}
+		if got[0].Status != Added {
+			t.Errorf("expected Added, got %v", got[0].Status)
+		}
+	})
+
+	t.Run("entry modified", func(t *testing.T) {
+		base := makeEntry("GitHub")
+		a := makeDatabase("a.kdbx", makeGroup("Passwords", atTime(base, t0)))
+		b := makeDatabase("b.kdbx", makeGroup("Passwords", atTime(base, t1)))
+
+		got := DiffDatabases(a, b)
+
+		if len(got) != 1 {
+			t.Fatalf("expected 1 diff, got %d", len(got))
+		}
+		if got[0].Status != Modified {
+			t.Errorf("expected Modified, got %v", got[0].Status)
+		}
+	})
+
+	t.Run("all statuses together", func(t *testing.T) {
+		unchanged := makeEntryAt("Unchanged", t0)
+		removed := makeEntryAt("Removed", t0)
+		added := makeEntryAt("Added", t0)
+		base := makeEntry("Modified")
+
+		a := makeDatabase("a.kdbx", makeGroup("G", unchanged, removed, atTime(base, t0)))
+		b := makeDatabase("b.kdbx", makeGroup("G", unchanged, added, atTime(base, t1)))
+
+		got := DiffDatabases(a, b)
+
+		if len(got) != 4 {
+			t.Fatalf("expected 4 diffs, got %d", len(got))
+		}
+		statusCount := map[ChangeStatus]int{}
+		for _, d := range got {
+			statusCount[d.Status]++
+		}
+		for _, status := range []ChangeStatus{Unchanged, Added, Removed, Modified} {
+			if statusCount[status] != 1 {
+				t.Errorf("expected exactly 1 of status %v, got %d", status, statusCount[status])
+			}
+		}
+	})
+
+	t.Run("results are sorted by path", func(t *testing.T) {
+		entryZ := makeEntryAt("ZEntry", t0)
+		entryA := makeEntryAt("AEntry", t0)
+		a := makeDatabase("a.kdbx", makeGroup("G", entryZ, entryA))
+		b := makeDatabase("b.kdbx", makeGroup("G", entryZ, entryA))
+
+		got := DiffDatabases(a, b)
+
+		for i := 1; i < len(got); i++ {
+			if got[i].Path < got[i-1].Path {
+				t.Errorf("results not sorted: %v before %v", got[i-1].Path, got[i].Path)
+			}
+		}
+	})
+}

--- a/pkg/kdbx/diff_test.go
+++ b/pkg/kdbx/diff_test.go
@@ -136,4 +136,29 @@ func TestDiffDatabases(t *testing.T) {
 			}
 		}
 	})
+
+	t.Run("same-path entries are ordered by UUID", func(t *testing.T) {
+		// Two entries with the same title (same path) but different UUIDs: one
+		// only in A (Removed) and one only in B (Added). The one with the smaller
+		// UUID must always come first regardless of map-iteration order.
+		low := makeEntryAt("Twin", t0)
+		low.UUID = UUID{0x00}
+		high := makeEntryAt("Twin", t0)
+		high.UUID = UUID{0xff}
+
+		a := makeDatabase("a.kdbx", makeGroup("G", low))
+		b := makeDatabase("b.kdbx", makeGroup("G", high))
+
+		got := DiffDatabases(a, b)
+
+		if len(got) != 2 {
+			t.Fatalf("expected 2 diffs, got %d", len(got))
+		}
+		if got[0].UUID != low.UUID {
+			t.Errorf("expected low UUID first, got %v", got[0].UUID)
+		}
+		if got[1].UUID != high.UUID {
+			t.Errorf("expected high UUID second, got %v", got[1].UUID)
+		}
+	})
 }

--- a/pkg/kdbx/format.go
+++ b/pkg/kdbx/format.go
@@ -48,19 +48,18 @@ func FormatDiff(nameA, nameB string, diffs []EntryDiff) string {
 	var sb strings.Builder
 	fmt.Fprintf(&sb, "--- %s\n", nameA)
 	fmt.Fprintf(&sb, "+++ %s\n", nameB)
-	fmt.Fprintf(&sb, "@@ -%d entries +%d entries @@\n", countA, countB)
+	fmt.Fprintf(&sb, "@@ -1,%d +1,%d @@\n", countA, countB)
 
 	for _, d := range changed {
-		var prefix string
 		switch d.Status {
 		case Removed:
-			prefix = "-"
+			fmt.Fprintf(&sb, "- %s\n", d.Path)
 		case Added:
-			prefix = "+"
+			fmt.Fprintf(&sb, "+ %s\n", d.Path)
 		case Modified:
-			prefix = "~"
+			fmt.Fprintf(&sb, "- %s\n", d.Path)
+			fmt.Fprintf(&sb, "+ %s\n", d.Path)
 		}
-		fmt.Fprintf(&sb, "%s %s\n", prefix, d.Path)
 	}
 
 	return sb.String()

--- a/pkg/kdbx/format.go
+++ b/pkg/kdbx/format.go
@@ -3,6 +3,7 @@ package kdbx
 import (
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/tobischo/gokeepasslib/v3"
 )
@@ -19,7 +20,9 @@ func formatEntryPath(groupPrefix string, entry gokeepasslib.Entry) EntityPath {
 	return groupPrefix + sanitizePathPortion(title)
 }
 
-func FormatDiff(nameA, nameB string, diffs []EntryDiff) string {
+const timestampLayout = "2006-01-02 15:04:05"
+
+func FormatDiff(nameA, nameB string, timeA, timeB time.Time, diffs []EntryDiff) string {
 	var countA, countB int
 	var changed []EntryDiff
 
@@ -54,8 +57,8 @@ func FormatDiff(nameA, nameB string, diffs []EntryDiff) string {
 	}
 
 	var sb strings.Builder
-	fmt.Fprintf(&sb, "--- %s\n", nameA)
-	fmt.Fprintf(&sb, "+++ %s\n", nameB)
+	fmt.Fprintf(&sb, "--- %s\t%s\n", nameA, timeA.Format(timestampLayout))
+	fmt.Fprintf(&sb, "+++ %s\t%s\n", nameB, timeB.Format(timestampLayout))
 	fmt.Fprintf(&sb, "@@ -%d,%d +%d,%d @@\n", startA, countA, startB, countB)
 
 	for _, d := range changed {

--- a/pkg/kdbx/format.go
+++ b/pkg/kdbx/format.go
@@ -1,0 +1,60 @@
+package kdbx
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/tobischo/gokeepasslib/v3"
+)
+
+func formatGroupPrefix(prefix string, g Group) string {
+	return prefix + g.Name + PATH_SEPARATOR
+}
+
+func formatEntryPath(groupPrefix string, entry gokeepasslib.Entry) EntityPath {
+	title := entry.GetTitle()
+	if title == "" {
+		title = "(UNKNOWN)"
+	}
+	return groupPrefix + sanitizePathPortion(title)
+}
+
+func FormatDiff(nameA, nameB string, diffs []EntryDiff) string {
+	var countA, countB int
+	for _, d := range diffs {
+		switch d.Status {
+		case Unchanged:
+			countA++
+			countB++
+		case Removed:
+			countA++
+		case Added:
+			countB++
+		case Modified:
+			countA++
+			countB++
+		}
+	}
+
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "--- %s\n", nameA)
+	fmt.Fprintf(&sb, "+++ %s\n", nameB)
+	fmt.Fprintf(&sb, "@@ -%d entries +%d entries @@\n", countA, countB)
+
+	for _, d := range diffs {
+		var prefix string
+		switch d.Status {
+		case Unchanged:
+			prefix = " "
+		case Removed:
+			prefix = "-"
+		case Added:
+			prefix = "+"
+		case Modified:
+			prefix = "~"
+		}
+		fmt.Fprintf(&sb, "%s %s\n", prefix, d.Path)
+	}
+
+	return sb.String()
+}

--- a/pkg/kdbx/format.go
+++ b/pkg/kdbx/format.go
@@ -45,10 +45,18 @@ func FormatDiff(nameA, nameB string, diffs []EntryDiff) string {
 		return ""
 	}
 
+	startA, startB := 1, 1
+	if countA == 0 {
+		startA = 0
+	}
+	if countB == 0 {
+		startB = 0
+	}
+
 	var sb strings.Builder
 	fmt.Fprintf(&sb, "--- %s\n", nameA)
 	fmt.Fprintf(&sb, "+++ %s\n", nameB)
-	fmt.Fprintf(&sb, "@@ -1,%d +1,%d @@\n", countA, countB)
+	fmt.Fprintf(&sb, "@@ -%d,%d +%d,%d @@\n", startA, countA, startB, countB)
 
 	for _, d := range changed {
 		switch d.Status {

--- a/pkg/kdbx/format.go
+++ b/pkg/kdbx/format.go
@@ -21,6 +21,8 @@ func formatEntryPath(groupPrefix string, entry gokeepasslib.Entry) EntityPath {
 
 func FormatDiff(nameA, nameB string, diffs []EntryDiff) string {
 	var countA, countB int
+	var changed []EntryDiff
+
 	for _, d := range diffs {
 		switch d.Status {
 		case Unchanged:
@@ -28,12 +30,19 @@ func FormatDiff(nameA, nameB string, diffs []EntryDiff) string {
 			countB++
 		case Removed:
 			countA++
+			changed = append(changed, d)
 		case Added:
 			countB++
+			changed = append(changed, d)
 		case Modified:
 			countA++
 			countB++
+			changed = append(changed, d)
 		}
+	}
+
+	if len(changed) == 0 {
+		return ""
 	}
 
 	var sb strings.Builder
@@ -41,11 +50,9 @@ func FormatDiff(nameA, nameB string, diffs []EntryDiff) string {
 	fmt.Fprintf(&sb, "+++ %s\n", nameB)
 	fmt.Fprintf(&sb, "@@ -%d entries +%d entries @@\n", countA, countB)
 
-	for _, d := range diffs {
+	for _, d := range changed {
 		var prefix string
 		switch d.Status {
-		case Unchanged:
-			prefix = " "
 		case Removed:
 			prefix = "-"
 		case Added:

--- a/pkg/kdbx/format.go
+++ b/pkg/kdbx/format.go
@@ -28,9 +28,6 @@ func FormatDiff(nameA, nameB string, timeA, timeB time.Time, diffs []EntryDiff) 
 
 	for _, d := range diffs {
 		switch d.Status {
-		case Unchanged:
-			countA++
-			countB++
 		case Removed:
 			countA++
 			changed = append(changed, d)

--- a/pkg/kdbx/format.go
+++ b/pkg/kdbx/format.go
@@ -61,12 +61,12 @@ func FormatDiff(nameA, nameB string, diffs []EntryDiff) string {
 	for _, d := range changed {
 		switch d.Status {
 		case Removed:
-			fmt.Fprintf(&sb, "- %s\n", d.Path)
+			fmt.Fprintf(&sb, "-%s\n", d.Path)
 		case Added:
-			fmt.Fprintf(&sb, "+ %s\n", d.Path)
+			fmt.Fprintf(&sb, "+%s\n", d.Path)
 		case Modified:
-			fmt.Fprintf(&sb, "- %s\n", d.Path)
-			fmt.Fprintf(&sb, "+ %s\n", d.Path)
+			fmt.Fprintf(&sb, "-%s\n", d.Path)
+			fmt.Fprintf(&sb, "+%s\n", d.Path)
 		}
 	}
 

--- a/pkg/kdbx/format_test.go
+++ b/pkg/kdbx/format_test.go
@@ -69,6 +69,30 @@ func TestFormatDiff(t *testing.T) {
 		}
 	})
 
+	t.Run("@@ start line is 0 when a is empty (all entries added)", func(t *testing.T) {
+		diffs := []EntryDiff{
+			{Path: "/G/Entry", Status: Added},
+		}
+
+		got := FormatDiff("a.kdbx", "b.kdbx", diffs)
+
+		if !strings.Contains(got, "@@ -0,0 +1,1 @@") {
+			t.Errorf("expected @@ -0,0 +1,1 @@, got:\n%s", got)
+		}
+	})
+
+	t.Run("@@ start line is 0 when b is empty (all entries removed)", func(t *testing.T) {
+		diffs := []EntryDiff{
+			{Path: "/G/Entry", Status: Removed},
+		}
+
+		got := FormatDiff("a.kdbx", "b.kdbx", diffs)
+
+		if !strings.Contains(got, "@@ -1,1 +0,0 @@") {
+			t.Errorf("expected @@ -1,1 +0,0 @@, got:\n%s", got)
+		}
+	})
+
 	t.Run("removed entries have - prefix", func(t *testing.T) {
 		got := FormatDiff("a.kdbx", "b.kdbx", []EntryDiff{{Path: "/G/Entry", Status: Removed}})
 

--- a/pkg/kdbx/format_test.go
+++ b/pkg/kdbx/format_test.go
@@ -96,7 +96,7 @@ func TestFormatDiff(t *testing.T) {
 	t.Run("removed entries have - prefix", func(t *testing.T) {
 		got := FormatDiff("a.kdbx", "b.kdbx", []EntryDiff{{Path: "/G/Entry", Status: Removed}})
 
-		if !strings.Contains(got, "- /G/Entry") {
+		if !strings.Contains(got, "-/G/Entry") {
 			t.Errorf("expected - prefixed entry, got:\n%s", got)
 		}
 	})
@@ -104,7 +104,7 @@ func TestFormatDiff(t *testing.T) {
 	t.Run("added entries have + prefix", func(t *testing.T) {
 		got := FormatDiff("a.kdbx", "b.kdbx", []EntryDiff{{Path: "/G/Entry", Status: Added}})
 
-		if !strings.Contains(got, "+ /G/Entry") {
+		if !strings.Contains(got, "+/G/Entry") {
 			t.Errorf("expected + prefixed entry, got:\n%s", got)
 		}
 	})
@@ -125,10 +125,10 @@ func TestFormatDiff(t *testing.T) {
 		if len(entryLines) != 2 {
 			t.Fatalf("expected 2 entry lines for modified, got %d:\n%s", len(entryLines), got)
 		}
-		if entryLines[0] != "- /G/Entry" {
+		if entryLines[0] != "-/G/Entry" {
 			t.Errorf("expected first line to be removal, got: %s", entryLines[0])
 		}
-		if entryLines[1] != "+ /G/Entry" {
+		if entryLines[1] != "+/G/Entry" {
 			t.Errorf("expected second line to be addition, got: %s", entryLines[1])
 		}
 	})

--- a/pkg/kdbx/format_test.go
+++ b/pkg/kdbx/format_test.go
@@ -52,7 +52,7 @@ func TestFormatDiff(t *testing.T) {
 		}
 	})
 
-	t.Run("@@ line counts all entries in each database", func(t *testing.T) {
+	t.Run("@@ line follows POSIX unified diff format", func(t *testing.T) {
 		diffs := []EntryDiff{
 			{Path: "/G/Unchanged", Status: Unchanged},
 			{Path: "/G/Removed", Status: Removed},
@@ -64,7 +64,7 @@ func TestFormatDiff(t *testing.T) {
 
 		// a has Unchanged + Removed + Modified = 3
 		// b has Unchanged + Added + Modified = 3
-		if !strings.Contains(got, "@@ -3 entries +3 entries @@") {
+		if !strings.Contains(got, "@@ -1,3 +1,3 @@") {
 			t.Errorf("unexpected @@ line, got:\n%s", got)
 		}
 	})
@@ -85,11 +85,27 @@ func TestFormatDiff(t *testing.T) {
 		}
 	})
 
-	t.Run("modified entries have ~ prefix", func(t *testing.T) {
+	t.Run("modified entries are shown as removal followed by addition", func(t *testing.T) {
 		got := FormatDiff("a.kdbx", "b.kdbx", []EntryDiff{{Path: "/G/Entry", Status: Modified}})
 
-		if !strings.Contains(got, "~ /G/Entry") {
-			t.Errorf("expected ~ prefixed entry, got:\n%s", got)
+		lines := strings.Split(strings.TrimSpace(got), "\n")
+		var entryLines []string
+		for _, l := range lines {
+			if strings.HasPrefix(l, "-") || strings.HasPrefix(l, "+") {
+				if !strings.HasPrefix(l, "---") && !strings.HasPrefix(l, "+++") {
+					entryLines = append(entryLines, l)
+				}
+			}
+		}
+
+		if len(entryLines) != 2 {
+			t.Fatalf("expected 2 entry lines for modified, got %d:\n%s", len(entryLines), got)
+		}
+		if entryLines[0] != "- /G/Entry" {
+			t.Errorf("expected first line to be removal, got: %s", entryLines[0])
+		}
+		if entryLines[1] != "+ /G/Entry" {
+			t.Errorf("expected second line to be addition, got: %s", entryLines[1])
 		}
 	})
 }

--- a/pkg/kdbx/format_test.go
+++ b/pkg/kdbx/format_test.go
@@ -3,6 +3,7 @@ package kdbx
 import (
 	"strings"
 	"testing"
+	"time"
 )
 
 func TestFormatDiff(t *testing.T) {
@@ -11,7 +12,7 @@ func TestFormatDiff(t *testing.T) {
 			{Path: "/G/Entry", Status: Unchanged},
 		}
 
-		got := FormatDiff("a.kdbx", "b.kdbx", diffs)
+		got := FormatDiff("a.kdbx", "b.kdbx", time.Time{}, time.Time{}, diffs)
 
 		if got != "" {
 			t.Errorf("expected empty string, got:\n%s", got)
@@ -19,7 +20,7 @@ func TestFormatDiff(t *testing.T) {
 	})
 
 	t.Run("returns empty string for empty input", func(t *testing.T) {
-		got := FormatDiff("a.kdbx", "b.kdbx", []EntryDiff{})
+		got := FormatDiff("a.kdbx", "b.kdbx", time.Time{}, time.Time{}, []EntryDiff{})
 
 		if got != "" {
 			t.Errorf("expected empty string, got:\n%s", got)
@@ -32,7 +33,7 @@ func TestFormatDiff(t *testing.T) {
 			{Path: "/G/Removed", Status: Removed},
 		}
 
-		got := FormatDiff("a.kdbx", "b.kdbx", diffs)
+		got := FormatDiff("a.kdbx", "b.kdbx", time.Time{}, time.Time{}, diffs)
 
 		if strings.Contains(got, "/G/Unchanged") {
 			t.Errorf("expected unchanged entry to be absent, got:\n%s", got)
@@ -42,13 +43,30 @@ func TestFormatDiff(t *testing.T) {
 	t.Run("headers contain file names", func(t *testing.T) {
 		diffs := []EntryDiff{{Path: "/G/Entry", Status: Removed}}
 
-		got := FormatDiff("old.kdbx", "new.kdbx", diffs)
+		got := FormatDiff("old.kdbx", "new.kdbx", time.Time{}, time.Time{}, diffs)
 
 		if !strings.Contains(got, "--- old.kdbx") {
 			t.Errorf("missing --- header, got:\n%s", got)
 		}
 		if !strings.Contains(got, "+++ new.kdbx") {
 			t.Errorf("missing +++ header, got:\n%s", got)
+		}
+	})
+
+	t.Run("headers contain timestamps", func(t *testing.T) {
+		tA := time.Date(2024, 1, 15, 10, 30, 0, 0, time.UTC)
+		tB := time.Date(2024, 6, 20, 18, 45, 0, 123456789, time.UTC)
+		diffs := []EntryDiff{{Path: "/G/Entry", Status: Removed}}
+
+		got := FormatDiff("a.kdbx", "b.kdbx", tA, tB, diffs)
+
+		wantA := "--- a.kdbx\t2024-01-15 10:30:00\n"
+		wantB := "+++ b.kdbx\t2024-06-20 18:45:00\n"
+		if !strings.Contains(got, wantA) {
+			t.Errorf("missing or malformed --- header, got:\n%s", got)
+		}
+		if !strings.Contains(got, wantB) {
+			t.Errorf("missing or malformed +++ header, got:\n%s", got)
 		}
 	})
 
@@ -60,7 +78,7 @@ func TestFormatDiff(t *testing.T) {
 			{Path: "/G/Modified", Status: Modified},
 		}
 
-		got := FormatDiff("a.kdbx", "b.kdbx", diffs)
+		got := FormatDiff("a.kdbx", "b.kdbx", time.Time{}, time.Time{}, diffs)
 
 		// a has Unchanged + Removed + Modified = 3
 		// b has Unchanged + Added + Modified = 3
@@ -74,7 +92,7 @@ func TestFormatDiff(t *testing.T) {
 			{Path: "/G/Entry", Status: Added},
 		}
 
-		got := FormatDiff("a.kdbx", "b.kdbx", diffs)
+		got := FormatDiff("a.kdbx", "b.kdbx", time.Time{}, time.Time{}, diffs)
 
 		if !strings.Contains(got, "@@ -0,0 +1,1 @@") {
 			t.Errorf("expected @@ -0,0 +1,1 @@, got:\n%s", got)
@@ -86,7 +104,7 @@ func TestFormatDiff(t *testing.T) {
 			{Path: "/G/Entry", Status: Removed},
 		}
 
-		got := FormatDiff("a.kdbx", "b.kdbx", diffs)
+		got := FormatDiff("a.kdbx", "b.kdbx", time.Time{}, time.Time{}, diffs)
 
 		if !strings.Contains(got, "@@ -1,1 +0,0 @@") {
 			t.Errorf("expected @@ -1,1 +0,0 @@, got:\n%s", got)
@@ -94,7 +112,7 @@ func TestFormatDiff(t *testing.T) {
 	})
 
 	t.Run("removed entries have - prefix", func(t *testing.T) {
-		got := FormatDiff("a.kdbx", "b.kdbx", []EntryDiff{{Path: "/G/Entry", Status: Removed}})
+		got := FormatDiff("a.kdbx", "b.kdbx", time.Time{}, time.Time{}, []EntryDiff{{Path: "/G/Entry", Status: Removed}})
 
 		if !strings.Contains(got, "-/G/Entry") {
 			t.Errorf("expected - prefixed entry, got:\n%s", got)
@@ -102,7 +120,7 @@ func TestFormatDiff(t *testing.T) {
 	})
 
 	t.Run("added entries have + prefix", func(t *testing.T) {
-		got := FormatDiff("a.kdbx", "b.kdbx", []EntryDiff{{Path: "/G/Entry", Status: Added}})
+		got := FormatDiff("a.kdbx", "b.kdbx", time.Time{}, time.Time{}, []EntryDiff{{Path: "/G/Entry", Status: Added}})
 
 		if !strings.Contains(got, "+/G/Entry") {
 			t.Errorf("expected + prefixed entry, got:\n%s", got)
@@ -110,7 +128,7 @@ func TestFormatDiff(t *testing.T) {
 	})
 
 	t.Run("modified entries are shown as removal followed by addition", func(t *testing.T) {
-		got := FormatDiff("a.kdbx", "b.kdbx", []EntryDiff{{Path: "/G/Entry", Status: Modified}})
+		got := FormatDiff("a.kdbx", "b.kdbx", time.Time{}, time.Time{}, []EntryDiff{{Path: "/G/Entry", Status: Modified}})
 
 		lines := strings.Split(strings.TrimSpace(got), "\n")
 		var entryLines []string

--- a/pkg/kdbx/format_test.go
+++ b/pkg/kdbx/format_test.go
@@ -80,9 +80,9 @@ func TestFormatDiff(t *testing.T) {
 
 		got := FormatDiff("a.kdbx", "b.kdbx", time.Time{}, time.Time{}, diffs)
 
-		// a has Unchanged + Removed + Modified = 3
-		// b has Unchanged + Added + Modified = 3
-		if !strings.Contains(got, "@@ -1,3 +1,3 @@") {
+		// a has Removed + Modified = 2 (Unchanged is not emitted)
+		// b has Added + Modified = 2 (Unchanged is not emitted)
+		if !strings.Contains(got, "@@ -1,2 +1,2 @@") {
 			t.Errorf("unexpected @@ line, got:\n%s", got)
 		}
 	})

--- a/pkg/kdbx/format_test.go
+++ b/pkg/kdbx/format_test.go
@@ -1,0 +1,68 @@
+package kdbx
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestFormatDiff(t *testing.T) {
+	t.Run("headers contain file names", func(t *testing.T) {
+		got := FormatDiff("old.kdbx", "new.kdbx", []EntryDiff{})
+
+		if !strings.Contains(got, "--- old.kdbx") {
+			t.Errorf("missing --- header, got:\n%s", got)
+		}
+		if !strings.Contains(got, "+++ new.kdbx") {
+			t.Errorf("missing +++ header, got:\n%s", got)
+		}
+	})
+
+	t.Run("@@ line counts entries in each database", func(t *testing.T) {
+		diffs := []EntryDiff{
+			{Path: "/G/Unchanged", Status: Unchanged},
+			{Path: "/G/Removed", Status: Removed},
+			{Path: "/G/Added", Status: Added},
+			{Path: "/G/Modified", Status: Modified},
+		}
+
+		got := FormatDiff("a.kdbx", "b.kdbx", diffs)
+
+		// a has Unchanged + Removed + Modified = 3
+		// b has Unchanged + Added + Modified = 3
+		if !strings.Contains(got, "@@ -3 entries +3 entries @@") {
+			t.Errorf("unexpected @@ line, got:\n%s", got)
+		}
+	})
+
+	t.Run("unchanged entries have space prefix", func(t *testing.T) {
+		got := FormatDiff("a.kdbx", "b.kdbx", []EntryDiff{{Path: "/G/Entry", Status: Unchanged}})
+
+		if !strings.Contains(got, "  /G/Entry") {
+			t.Errorf("expected space-prefixed entry, got:\n%s", got)
+		}
+	})
+
+	t.Run("removed entries have - prefix", func(t *testing.T) {
+		got := FormatDiff("a.kdbx", "b.kdbx", []EntryDiff{{Path: "/G/Entry", Status: Removed}})
+
+		if !strings.Contains(got, "- /G/Entry") {
+			t.Errorf("expected - prefixed entry, got:\n%s", got)
+		}
+	})
+
+	t.Run("added entries have + prefix", func(t *testing.T) {
+		got := FormatDiff("a.kdbx", "b.kdbx", []EntryDiff{{Path: "/G/Entry", Status: Added}})
+
+		if !strings.Contains(got, "+ /G/Entry") {
+			t.Errorf("expected + prefixed entry, got:\n%s", got)
+		}
+	})
+
+	t.Run("modified entries have ~ prefix", func(t *testing.T) {
+		got := FormatDiff("a.kdbx", "b.kdbx", []EntryDiff{{Path: "/G/Entry", Status: Modified}})
+
+		if !strings.Contains(got, "~ /G/Entry") {
+			t.Errorf("expected ~ prefixed entry, got:\n%s", got)
+		}
+	})
+}

--- a/pkg/kdbx/format_test.go
+++ b/pkg/kdbx/format_test.go
@@ -6,8 +6,43 @@ import (
 )
 
 func TestFormatDiff(t *testing.T) {
+	t.Run("returns empty string when there are no changes", func(t *testing.T) {
+		diffs := []EntryDiff{
+			{Path: "/G/Entry", Status: Unchanged},
+		}
+
+		got := FormatDiff("a.kdbx", "b.kdbx", diffs)
+
+		if got != "" {
+			t.Errorf("expected empty string, got:\n%s", got)
+		}
+	})
+
+	t.Run("returns empty string for empty input", func(t *testing.T) {
+		got := FormatDiff("a.kdbx", "b.kdbx", []EntryDiff{})
+
+		if got != "" {
+			t.Errorf("expected empty string, got:\n%s", got)
+		}
+	})
+
+	t.Run("unchanged entries are not shown", func(t *testing.T) {
+		diffs := []EntryDiff{
+			{Path: "/G/Unchanged", Status: Unchanged},
+			{Path: "/G/Removed", Status: Removed},
+		}
+
+		got := FormatDiff("a.kdbx", "b.kdbx", diffs)
+
+		if strings.Contains(got, "/G/Unchanged") {
+			t.Errorf("expected unchanged entry to be absent, got:\n%s", got)
+		}
+	})
+
 	t.Run("headers contain file names", func(t *testing.T) {
-		got := FormatDiff("old.kdbx", "new.kdbx", []EntryDiff{})
+		diffs := []EntryDiff{{Path: "/G/Entry", Status: Removed}}
+
+		got := FormatDiff("old.kdbx", "new.kdbx", diffs)
 
 		if !strings.Contains(got, "--- old.kdbx") {
 			t.Errorf("missing --- header, got:\n%s", got)
@@ -17,7 +52,7 @@ func TestFormatDiff(t *testing.T) {
 		}
 	})
 
-	t.Run("@@ line counts entries in each database", func(t *testing.T) {
+	t.Run("@@ line counts all entries in each database", func(t *testing.T) {
 		diffs := []EntryDiff{
 			{Path: "/G/Unchanged", Status: Unchanged},
 			{Path: "/G/Removed", Status: Removed},
@@ -31,14 +66,6 @@ func TestFormatDiff(t *testing.T) {
 		// b has Unchanged + Added + Modified = 3
 		if !strings.Contains(got, "@@ -3 entries +3 entries @@") {
 			t.Errorf("unexpected @@ line, got:\n%s", got)
-		}
-	})
-
-	t.Run("unchanged entries have space prefix", func(t *testing.T) {
-		got := FormatDiff("a.kdbx", "b.kdbx", []EntryDiff{{Path: "/G/Entry", Status: Unchanged}})
-
-		if !strings.Contains(got, "  /G/Entry") {
-			t.Errorf("expected space-prefixed entry, got:\n%s", got)
 		}
 	})
 

--- a/pkg/kdbx/kdbx.go
+++ b/pkg/kdbx/kdbx.go
@@ -357,20 +357,8 @@ func (d *Database) unlock() error {
 	return nil
 }
 
-func makeGroupPrefix(prefix string, g Group) string {
-	return prefix + g.Name + PATH_SEPARATOR
-}
-
-func makeEntryPath(groupPrefix string, entry gokeepasslib.Entry) EntityPath {
-	title := entry.GetTitle()
-	if title == "" {
-		title = "(UNKNOWN)"
-	}
-	return groupPrefix + sanitizePathPortion(title)
-}
-
 func getEntityPathsFromGroup(g Group, prefix string) []uniqueEntityPath {
-	groupPrefix := makeGroupPrefix(prefix, g)
+	groupPrefix := formatGroupPrefix(prefix, g)
 	entries := []uniqueEntityPath{}
 
 	for _, subGroup := range g.Groups {
@@ -379,14 +367,14 @@ func getEntityPathsFromGroup(g Group, prefix string) []uniqueEntityPath {
 	}
 
 	for _, entry := range g.Entries {
-		entries = append(entries, uniqueEntityPath{path: makeEntryPath(groupPrefix, entry), uuid: entry.UUID})
+		entries = append(entries, uniqueEntityPath{path: formatEntryPath(groupPrefix, entry), uuid: entry.UUID})
 	}
 
 	return entries
 }
 
 func getGroupPathsFromGroup(g Group, prefix string) []uniqueEntityPath {
-	groupPrefix := makeGroupPrefix(prefix, g)
+	groupPrefix := formatGroupPrefix(prefix, g)
 	paths := []uniqueEntityPath{}
 
 	paths = append(paths, uniqueEntityPath{path: groupPrefix, uuid: g.UUID})

--- a/pkg/kdbx/kdbx.go
+++ b/pkg/kdbx/kdbx.go
@@ -357,8 +357,20 @@ func (d *Database) unlock() error {
 	return nil
 }
 
+func makeGroupPrefix(prefix string, g Group) string {
+	return prefix + g.Name + PATH_SEPARATOR
+}
+
+func makeEntryPath(groupPrefix string, entry gokeepasslib.Entry) EntityPath {
+	title := entry.GetTitle()
+	if title == "" {
+		title = "(UNKNOWN)"
+	}
+	return groupPrefix + sanitizePathPortion(title)
+}
+
 func getEntityPathsFromGroup(g Group, prefix string) []uniqueEntityPath {
-	groupPrefix := prefix + g.Name + PATH_SEPARATOR
+	groupPrefix := makeGroupPrefix(prefix, g)
 	entries := []uniqueEntityPath{}
 
 	for _, subGroup := range g.Groups {
@@ -367,21 +379,14 @@ func getEntityPathsFromGroup(g Group, prefix string) []uniqueEntityPath {
 	}
 
 	for _, entry := range g.Entries {
-		title := entry.GetTitle()
-
-		if title == "" {
-			title = "(UNKNOWN)"
-		}
-
-		key := groupPrefix + sanitizePathPortion(title)
-		entries = append(entries, uniqueEntityPath{path: key, uuid: entry.UUID})
+		entries = append(entries, uniqueEntityPath{path: makeEntryPath(groupPrefix, entry), uuid: entry.UUID})
 	}
 
 	return entries
 }
 
 func getGroupPathsFromGroup(g Group, prefix string) []uniqueEntityPath {
-	groupPrefix := prefix + g.Name + PATH_SEPARATOR
+	groupPrefix := makeGroupPrefix(prefix, g)
 	paths := []uniqueEntityPath{}
 
 	paths = append(paths, uniqueEntityPath{path: groupPrefix, uuid: g.UUID})

--- a/test/cli_test.go
+++ b/test/cli_test.go
@@ -877,8 +877,8 @@ func TestCommandDiff(t *testing.T) {
 		if exitCode == 0 {
 			t.Fatal("expected non-zero exit code")
 		}
-		if !strings.Contains(stderr, "no such file or directory") {
-			t.Errorf("expected 'no such file or directory' in stderr, got:\n%s", stderr)
+		if !strings.Contains(stderr, "non-existent.kdbx") {
+			t.Errorf("expected filename in error, got:\n%s", stderr)
 		}
 	})
 
@@ -891,8 +891,24 @@ func TestCommandDiff(t *testing.T) {
 		if exitCode == 0 {
 			t.Fatal("expected non-zero exit code")
 		}
+		if !strings.Contains(stderr, "non-existent.kdbx") {
+			t.Errorf("expected filename in error, got:\n%s", stderr)
+		}
+	})
+
+	t.Run("checks file existence before prompting for passphrase", func(t *testing.T) {
+		// No env vars: without an early file check the binary would write a
+		// passphrase prompt to stderr before discovering the file is missing.
+		_, stderr, exitCode := runKeydex(t, nil, "diff", "non-existent.kdbx", fixtureDB2)
+
+		if exitCode == 0 {
+			t.Fatal("expected non-zero exit code")
+		}
+		if strings.Contains(stderr, "Passphrase for") {
+			t.Errorf("passphrase was prompted before file existence was checked, stderr:\n%s", stderr)
+		}
 		if !strings.Contains(stderr, "no such file or directory") {
-			t.Errorf("expected 'no such file or directory' in stderr, got:\n%s", stderr)
+			t.Errorf("expected file error in stderr, got:\n%s", stderr)
 		}
 	})
 }

--- a/test/cli_test.go
+++ b/test/cli_test.go
@@ -20,6 +20,8 @@ import (
 const binaryPath = "./" + info.NAME
 const fixtureDB = "test.kdbx"
 const fixturePassword = "test-password"
+const fixtureDB2 = "test2.kdbx"
+const fixturePassword2 = "test-password-2"
 
 func createFixtureDB() error {
 	file, err := os.Create(fixtureDB)
@@ -100,9 +102,14 @@ func TestMain(m *testing.M) {
 		panic(err.Error())
 	}
 
+	if err = createFixtureDB2(); err != nil {
+		panic(err.Error())
+	}
+
 	code := m.Run()
 
 	os.RemoveAll(fixtureDB)
+	os.RemoveAll(fixtureDB2)
 	os.Exit(code)
 }
 
@@ -721,6 +728,162 @@ func TestCommandCreateWithPassphrase(t *testing.T) {
 		}
 		if _, err := os.Stat(dbPath); !os.IsNotExist(err) {
 			t.Error("expected no database file to be created when keyfile already exists")
+		}
+	})
+}
+
+func createFixtureDB2() error {
+	file, err := os.Create(fixtureDB2)
+	if err != nil {
+		return err
+	}
+
+	db, err := kdbx.NewFromFile(file)
+	if err != nil {
+		return err
+	}
+	if err := db.SetPasswordAndKey(fixturePassword2, ""); err != nil {
+		return err
+	}
+
+	rootGroup := db.NewGroup("TestDB2")
+	socialGroup := db.NewGroup("Social")
+
+	twitter := gokeepasslib.NewEntry()
+	twitter.Values = append(twitter.Values,
+		gokeepasslib.ValueData{
+			Key:   "Title",
+			Value: gokeepasslib.V{Content: "Twitter"}},
+		gokeepasslib.ValueData{
+			Key: "Password",
+			Value: gokeepasslib.V{
+				Content:   "twpass",
+				Protected: wrappers.NewBoolWrapper(true)}},
+	)
+
+	socialGroup.Entries = append(socialGroup.Entries, twitter)
+	rootGroup.Groups = append(rootGroup.Groups, *socialGroup)
+	db.Content.Root.Groups = []gokeepasslib.Group{*rootGroup}
+
+	return db.Save()
+}
+
+func TestCommandDiff(t *testing.T) {
+	t.Run("diff identical archives outputs nothing", func(t *testing.T) {
+		stdout, stderr, exitCode := runKeydex(t, map[string]string{
+			"KEYDEX_PASSPHRASE_A": fixturePassword,
+			"KEYDEX_PASSPHRASE_B": fixturePassword,
+		}, "diff", fixtureDB, fixtureDB)
+
+		if exitCode != 0 {
+			t.Fatalf("expected exit code 0, got %d. stderr: %s", exitCode, stderr)
+		}
+		if stdout != "" {
+			t.Errorf("expected empty output, got:\n%s", stdout)
+		}
+	})
+
+	t.Run("diff different archives shows added and removed entries", func(t *testing.T) {
+		stdout, stderr, exitCode := runKeydex(t, map[string]string{
+			"KEYDEX_PASSPHRASE_A": fixturePassword,
+			"KEYDEX_PASSPHRASE_B": fixturePassword2,
+		}, "diff", fixtureDB, fixtureDB2)
+
+		if exitCode != 0 {
+			t.Fatalf("expected exit code 0, got %d. stderr: %s", exitCode, stderr)
+		}
+		if !strings.Contains(stdout, "- /") {
+			t.Errorf("expected removed entries in output, got:\n%s", stdout)
+		}
+		if !strings.Contains(stdout, "+ /") {
+			t.Errorf("expected added entries in output, got:\n%s", stdout)
+		}
+	})
+
+	t.Run("output includes file name headers", func(t *testing.T) {
+		stdout, stderr, exitCode := runKeydex(t, map[string]string{
+			"KEYDEX_PASSPHRASE_A": fixturePassword,
+			"KEYDEX_PASSPHRASE_B": fixturePassword2,
+		}, "diff", fixtureDB, fixtureDB2)
+
+		if exitCode != 0 {
+			t.Fatalf("expected exit code 0, got %d. stderr: %s", exitCode, stderr)
+		}
+		if !strings.Contains(stdout, "--- "+fixtureDB) {
+			t.Errorf("expected --- header in output, got:\n%s", stdout)
+		}
+		if !strings.Contains(stdout, "+++ "+fixtureDB2) {
+			t.Errorf("expected +++ header in output, got:\n%s", stdout)
+		}
+	})
+
+	t.Run("output includes entry count line", func(t *testing.T) {
+		stdout, stderr, exitCode := runKeydex(t, map[string]string{
+			"KEYDEX_PASSPHRASE_A": fixturePassword,
+			"KEYDEX_PASSPHRASE_B": fixturePassword2,
+		}, "diff", fixtureDB, fixtureDB2)
+
+		if exitCode != 0 {
+			t.Fatalf("expected exit code 0, got %d. stderr: %s", exitCode, stderr)
+		}
+		if !strings.Contains(stdout, "@@ -") {
+			t.Errorf("expected @@ line in output, got:\n%s", stdout)
+		}
+	})
+
+	t.Run("fails with wrong password for first archive", func(t *testing.T) {
+		stdout, stderr, exitCode := runKeydex(t, map[string]string{
+			"KEYDEX_PASSPHRASE_A": "wrong-password",
+			"KEYDEX_PASSPHRASE_B": fixturePassword2,
+		}, "diff", fixtureDB, fixtureDB2)
+
+		if exitCode == 0 {
+			t.Fatalf("expected non-zero exit code, got 0. stdout: %s", stdout)
+		}
+		if !strings.Contains(stderr, "Wrong password?") {
+			t.Errorf("expected 'Wrong password?' in stderr, got:\n%s", stderr)
+		}
+	})
+
+	t.Run("fails with wrong password for second archive", func(t *testing.T) {
+		stdout, stderr, exitCode := runKeydex(t, map[string]string{
+			"KEYDEX_PASSPHRASE_A": fixturePassword,
+			"KEYDEX_PASSPHRASE_B": "wrong-password",
+		}, "diff", fixtureDB, fixtureDB2)
+
+		if exitCode == 0 {
+			t.Fatalf("expected non-zero exit code, got 0. stdout: %s", stdout)
+		}
+		if !strings.Contains(stderr, "Wrong password?") {
+			t.Errorf("expected 'Wrong password?' in stderr, got:\n%s", stderr)
+		}
+	})
+
+	t.Run("fails with non-existing first archive", func(t *testing.T) {
+		_, stderr, exitCode := runKeydex(t, map[string]string{
+			"KEYDEX_PASSPHRASE_A": fixturePassword,
+			"KEYDEX_PASSPHRASE_B": fixturePassword2,
+		}, "diff", "non-existent.kdbx", fixtureDB2)
+
+		if exitCode == 0 {
+			t.Fatal("expected non-zero exit code")
+		}
+		if !strings.Contains(stderr, "no such file or directory") {
+			t.Errorf("expected 'no such file or directory' in stderr, got:\n%s", stderr)
+		}
+	})
+
+	t.Run("fails with non-existing second archive", func(t *testing.T) {
+		_, stderr, exitCode := runKeydex(t, map[string]string{
+			"KEYDEX_PASSPHRASE_A": fixturePassword,
+			"KEYDEX_PASSPHRASE_B": fixturePassword2,
+		}, "diff", fixtureDB, "non-existent.kdbx")
+
+		if exitCode == 0 {
+			t.Fatal("expected non-zero exit code")
+		}
+		if !strings.Contains(stderr, "no such file or directory") {
+			t.Errorf("expected 'no such file or directory' in stderr, got:\n%s", stderr)
 		}
 	})
 }

--- a/test/cli_test.go
+++ b/test/cli_test.go
@@ -801,19 +801,28 @@ func TestCommandDiff(t *testing.T) {
 	})
 
 	t.Run("output includes file name headers", func(t *testing.T) {
+		absA, _ := filepath.Abs(fixtureDB)
+		absB, _ := filepath.Abs(fixtureDB2)
+
 		stdout, stderr, exitCode := runKeydex(t, map[string]string{
 			"KEYDEX_PASSPHRASE_A": fixturePassword,
 			"KEYDEX_PASSPHRASE_B": fixturePassword2,
-		}, "diff", fixtureDB, fixtureDB2)
+		}, "diff", absA, absB)
 
 		if exitCode != 0 {
 			t.Fatalf("expected exit code 0, got %d. stderr: %s", exitCode, stderr)
 		}
 		if !strings.Contains(stdout, "--- "+fixtureDB) {
-			t.Errorf("expected --- header in output, got:\n%s", stdout)
+			t.Errorf("expected --- header with base name in output, got:\n%s", stdout)
 		}
 		if !strings.Contains(stdout, "+++ "+fixtureDB2) {
-			t.Errorf("expected +++ header in output, got:\n%s", stdout)
+			t.Errorf("expected +++ header with base name in output, got:\n%s", stdout)
+		}
+		if strings.Contains(stdout, absA) {
+			t.Errorf("expected full path to be absent from output, got:\n%s", stdout)
+		}
+		if strings.Contains(stdout, absB) {
+			t.Errorf("expected full path to be absent from output, got:\n%s", stdout)
 		}
 	})
 

--- a/test/cli_test.go
+++ b/test/cli_test.go
@@ -792,10 +792,10 @@ func TestCommandDiff(t *testing.T) {
 		if exitCode != 0 {
 			t.Fatalf("expected exit code 0, got %d. stderr: %s", exitCode, stderr)
 		}
-		if !strings.Contains(stdout, "- /") {
+		if !strings.Contains(stdout, "-/") {
 			t.Errorf("expected removed entries in output, got:\n%s", stdout)
 		}
-		if !strings.Contains(stdout, "+ /") {
+		if !strings.Contains(stdout, "+/") {
 			t.Errorf("expected added entries in output, got:\n%s", stdout)
 		}
 	})


### PR DESCRIPTION
This change introduces a `diff` command to compare two archives. The comparison does not introspect the entries and it's purely based on timestamps.

The output format is based on POSIX unified diffs, so that it can be piped into other tools for interoperability.

Closes #35 